### PR TITLE
添加NewtonsoftJson支持

### DIFF
--- a/WebApiClientCore.Test/Serialization/JsonSerializerTest.cs
+++ b/WebApiClientCore.Test/Serialization/JsonSerializerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using WebApiClientCore.Serialization;
 using Xunit;
 
 namespace WebApiClientCore.Test.Serialization
@@ -23,9 +24,36 @@ namespace WebApiClientCore.Test.Serialization
 
             buffer.Clear();
 
-            formatter.Serialize(buffer,dic, options);
+            formatter.Serialize(buffer, dic, options);
             var json2 = Encoding.UTF8.GetString(buffer.GetWrittenSpan().ToArray());
             Assert.Contains("key", json2);
+        }
+    }
+
+    public class NewtonsoftJsonSerializerTest
+    {
+        [Fact]
+        public void ReadWriteTest()
+        {
+            var options = new HttpApiOptions().JsonSerializeOptions;
+
+            var obj1 = new FormatModel { Age = 18, Name = "老九" };
+            var formatter = NewtonsoftJsonSerializer.CreateJsonSerializer();
+
+            using var buffer = new BufferWriter<byte>();
+            formatter.Serialize(buffer, obj1, options);
+            var json = buffer.GetWrittenSpan().ToArray();
+            var obj2 = formatter.Deserialize(json, typeof(FormatModel), options);
+            Assert.True(obj1.Equals(obj2));
+
+            var dic = new System.Collections.Concurrent.ConcurrentDictionary<string, object>();
+            dic.TryAdd("Key", "Value");
+
+            buffer.Clear();
+
+            formatter.Serialize(buffer, dic, options);
+            var json2 = Encoding.UTF8.GetString(buffer.GetWrittenSpan().ToArray());
+            Assert.Contains("Key", json2);
         }
     }
 }

--- a/WebApiClientCore/Microsoft.Extensions/DependencyInjection/HttpApiConfigureExtensions.cs
+++ b/WebApiClientCore/Microsoft.Extensions/DependencyInjection/HttpApiConfigureExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Newtonsoft.Json;
 using System;
+using System.Linq;
 using WebApiClientCore;
+using WebApiClientCore.Serialization;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -23,9 +27,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// 配置HttpApi
-        /// </summary> 
+        /// </summary>
         /// <param name="services"></param>
-        /// <param name="httpApiType">接口类型</param> 
+        /// <param name="httpApiType">接口类型</param>
         /// <param name="configureOptions">配置选项</param>
         /// <returns></returns>
         public static IServiceCollection ConfigureHttpApi(this IServiceCollection services, Type httpApiType, Action<HttpApiOptions> configureOptions)
@@ -47,14 +51,34 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// 配置HttpApi
-        /// </summary> 
+        /// </summary>
         /// <param name="services"></param>
-        /// <param name="httpApiType">接口类型</param> 
+        /// <param name="httpApiType">接口类型</param>
         /// <param name="configureOptions">配置选项</param>
         /// <returns></returns>
         public static IServiceCollection ConfigureHttpApi(this IServiceCollection services, Type httpApiType, IConfiguration configureOptions)
         {
             return services.Configure<HttpApiOptions>(httpApiType.FullName, configureOptions);
+        }
+
+        /// <summary>
+        /// 配置HttpApi序列化json时使用NewtonsoftJson
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="optionAction"></param>
+        /// <returns></returns>
+        public static IServiceCollection ConfigureHttpApiUseNewtonsoftJson(this IServiceCollection services, Action<JsonSerializerSettings?>? optionAction = null)
+        {
+            ServiceDescriptor sd = services.FirstOrDefault(t => t.ServiceType == typeof(IJsonSerializer));
+
+            if (sd != null)
+            {
+                services.Remove(sd);
+            }
+
+            services.AddSingleton<IJsonSerializer, NewtonsoftJsonSerializer>(t => NewtonsoftJsonSerializer.CreateJsonSerializer(optionAction));
+
+            return services;
         }
     }
 }

--- a/WebApiClientCore/Microsoft.Extensions/DependencyInjection/HttpApiConfigureExtensions.cs
+++ b/WebApiClientCore/Microsoft.Extensions/DependencyInjection/HttpApiConfigureExtensions.cs
@@ -69,15 +69,24 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IServiceCollection ConfigureHttpApiUseNewtonsoftJson(this IServiceCollection services, Action<JsonSerializerSettings?>? optionAction = null)
         {
-            ServiceDescriptor sd = services.FirstOrDefault(t => t.ServiceType == typeof(IJsonSerializer));
+            Type serviceType = typeof(IJsonSerializer);
+            ServiceDescriptor sd = services.FirstOrDefault(t => t.ServiceType == serviceType);
 
-            if (sd != null)
+            if (sd == null)//未添加过，需要添加
             {
-                services.Remove(sd);
+                services.AddSingleton<IJsonSerializer, NewtonsoftJsonSerializer>(t => NewtonsoftJsonSerializer.CreateJsonSerializer(optionAction));
+                return services;
             }
 
-            services.AddSingleton<IJsonSerializer, NewtonsoftJsonSerializer>(t => NewtonsoftJsonSerializer.CreateJsonSerializer(optionAction));
+            Type implementationType = typeof(NewtonsoftJsonSerializer);
+            if (sd.ImplementationType != implementationType)//需要替换
+            {
+                services.Remove(sd);
+                services.AddSingleton<IJsonSerializer, NewtonsoftJsonSerializer>(t => NewtonsoftJsonSerializer.CreateJsonSerializer(optionAction));
+                return services;
+            }
 
+            //不需要替换
             return services;
         }
     }

--- a/WebApiClientCore/Microsoft.Extensions/DependencyInjection/HttpApiExtensions.cs
+++ b/WebApiClientCore/Microsoft.Extensions/DependencyInjection/HttpApiExtensions.cs
@@ -65,7 +65,6 @@ namespace Microsoft.Extensions.DependencyInjection
             return services.AddHttpApi<THttpApi>();
         }
 
-
         /// <summary>
         /// 添加HttpApi代理类到服务
         /// </summary>
@@ -114,6 +113,8 @@ namespace Microsoft.Extensions.DependencyInjection
             return services.AddHttpApi(httpApiType);
         }
 
+        #region 定义httpApi的Builder的行为
+
         /// <summary>
         /// 定义httpApi的Builder的行为
         /// </summary>
@@ -145,12 +146,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
             /// <summary>
             /// 添加HttpApi代理类到服务
-            /// </summary> 
+            /// </summary>
             /// <returns></returns>
             public IHttpClientBuilder AddHttpApi()
             {
                 return this.services.AddHttpApi<THttpApi>();
             }
         }
+
+        #endregion 定义httpApi的Builder的行为
     }
 }

--- a/WebApiClientCore/Serialization/IJsonSerializer.cs
+++ b/WebApiClientCore/Serialization/IJsonSerializer.cs
@@ -12,7 +12,7 @@ namespace WebApiClientCore.Serialization
     public interface IJsonSerializer
     {
         /// <summary>
-        /// 将对象序列化为utf8编码的Json到指定的bufferWriter
+        /// 将对象序列化为 utf8编码的Json 到指定的bufferWriter
         /// </summary>
         /// <param name="bufferWriter">buffer写入器</param>
         /// <param name="obj">对象</param>
@@ -20,7 +20,7 @@ namespace WebApiClientCore.Serialization
         void Serialize(IBufferWriter<byte> bufferWriter, object? obj, JsonSerializerOptions? options);
 
         /// <summary>
-        /// 将utf8编码的Json反序列化对象
+        /// 将utf8编码的Json反序列化为对象
         /// </summary>
         /// <param name="utf8Json">utf8编码的Json</param>
         /// <param name="objType">对象类型</param>
@@ -29,12 +29,12 @@ namespace WebApiClientCore.Serialization
         object? Deserialize(ReadOnlySpan<byte> utf8Json, Type objType, JsonSerializerOptions? options);
 
         /// <summary>
-        /// 将utf8编码的Json流反序列化对象
+        /// 将utf8编码的Json流 反序列化为对象
         /// </summary>
-        /// <param name="utf8Json">utf8编码的Json流</param>
+        /// <param name="utf8JsonStream">utf8编码的Json流</param>
         /// <param name="objType">对象类型</param>
         /// <param name="options">选项</param>
         /// <returns></returns>
-        Task<object> DeserializeAsync(Stream utf8Json, Type objType, JsonSerializerOptions? options);
+        Task<object> DeserializeAsync(Stream utf8JsonStream, Type objType, JsonSerializerOptions? options);
     }
 }

--- a/WebApiClientCore/Serialization/JsonSerializer.cs
+++ b/WebApiClientCore/Serialization/JsonSerializer.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace WebApiClientCore.Serialization
 {
@@ -17,7 +18,7 @@ namespace WebApiClientCore.Serialization
         private static readonly JsonSerializerOptions defaultOptions = new JsonSerializerOptions();
 
         /// <summary>
-        /// 将对象序列化为utf8编码的Json到指定的bufferWriter
+        ///  将对象序列化为 utf8编码的Json 到指定的bufferWriter
         /// </summary>
         /// <param name="bufferWriter">buffer写入器</param>
         /// <param name="obj">对象</param>
@@ -42,7 +43,7 @@ namespace WebApiClientCore.Serialization
         }
 
         /// <summary>
-        /// 反序列化utf8编码的Json为对象
+        /// 将utf8编码的Json反序列化为对象
         /// </summary>
         /// <param name="utf8Json">json</param>
         /// <param name="objType">对象类型</param>
@@ -56,15 +57,15 @@ namespace WebApiClientCore.Serialization
         }
 
         /// <summary>
-        /// 将utf8编码的Json流反序列化对象
+        /// 将utf8编码的Json流 反序列化为对象
         /// </summary>
-        /// <param name="utf8Json">utf8编码的Json流</param>
+        /// <param name="utf8JsonStream">utf8编码的Json流</param>
         /// <param name="objType">对象类型</param>
         /// <param name="options">选项</param>
         /// <returns></returns>
-        public Task<object> DeserializeAsync(Stream utf8Json, Type objType, JsonSerializerOptions? options)
+        public Task<object> DeserializeAsync(Stream utf8JsonStream, Type objType, JsonSerializerOptions? options)
         {
-            return System.Text.Json.JsonSerializer.DeserializeAsync(utf8Json, objType, options).AsTask();
+            return System.Text.Json.JsonSerializer.DeserializeAsync(utf8JsonStream, objType, options).AsTask();
         }
     }
 }

--- a/WebApiClientCore/Serialization/NewtonsoftJsonSerializer.cs
+++ b/WebApiClientCore/Serialization/NewtonsoftJsonSerializer.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace WebApiClientCore.Serialization
+{
+    /// <summary>
+    /// Newtonsoft.Json的json序列化工具
+    /// </summary>
+    public class NewtonsoftJsonSerializer : IJsonSerializer
+    {
+        private static readonly JsonSerializerSettings defaultOptions = new JsonSerializerSettings();
+
+        /// <summary>
+        /// json序列化设置
+        /// </summary>
+        /// <remarks>
+        /// 2020-07-11 因接口限制，接口上面的方法必须使用<see cref="System.Text.Json.JsonSerializerOptions"/>,与Newtonsoft.Json的设置不兼容,所以需要使用这个字段来接收注册服务时配置的json配置，不使用接口传递的
+        /// </remarks>
+        private readonly JsonSerializerSettings? jsonOptions;
+
+        private NewtonsoftJsonSerializer(JsonSerializerSettings? jsonOptions)
+        {
+            this.jsonOptions = jsonOptions ?? defaultOptions;
+        }
+
+        /// <summary>
+        /// 将对象序列化为 utf8编码的Json 到指定的bufferWriter
+        /// </summary>
+        /// <param name="bufferWriter">buffer写入器</param>
+        /// <param name="obj">对象</param>
+        /// <param name="options">选项</param>
+        public void Serialize(IBufferWriter<byte> bufferWriter, object? obj, JsonSerializerOptions? options)
+        {
+            if (obj == null || bufferWriter == null)
+            {
+                return;
+            }
+
+            string jsonStr = JsonConvert.SerializeObject(obj, obj.GetType(), this.jsonOptions);
+            ReadOnlySpan<byte> bytes = Encoding.UTF8.GetBytes(jsonStr).AsSpan();
+            bufferWriter.Write(bytes);
+        }
+
+        /// <summary>
+        /// 将utf8编码的Json反序列化为对象
+        /// </summary>
+        /// <param name="utf8Json">json</param>
+        /// <param name="objType">对象类型</param>
+        /// <param name="options">选项</param>
+        /// <returns></returns>
+        public object? Deserialize(ReadOnlySpan<byte> utf8Json, Type objType, JsonSerializerOptions? options)
+        {
+            return utf8Json.IsEmpty
+                ? objType.DefaultValue()
+                : deserialize(utf8Json, objType);
+
+            object? deserialize(ReadOnlySpan<byte> utf8Json2, Type objType2)
+            {
+                string objStr = Encoding.UTF8.GetString(utf8Json2);
+                return JsonConvert.DeserializeObject(new string(objStr), objType2);
+            }
+        }
+
+        /// <summary>
+        /// 将utf8编码的Json流 反序列化为对象
+        /// </summary>
+        /// <param name="utf8JsonStream">utf8编码的Json流</param>
+        /// <param name="objType">对象类型</param>
+        /// <param name="options">选项</param>
+        /// <returns></returns>
+        public async Task<object> DeserializeAsync(Stream utf8JsonStream, Type objType, JsonSerializerOptions? options)
+        {
+#pragma warning disable CS8603 // 可能的 null 引用返回。
+            StreamReader streamReader = new StreamReader(utf8JsonStream, Encoding.UTF8);
+            string jsonStr = await streamReader.ReadToEndAsync();
+            if (string.IsNullOrEmpty(jsonStr))
+            {
+                return objType.DefaultValue();
+            }
+            else
+            {
+                return JsonConvert.DeserializeObject(jsonStr, objType, this.jsonOptions);
+            }
+
+#pragma warning restore CS8603 // 可能的 null 引用返回。
+        }
+
+        /// <summary>
+        /// 创建 NewtonsoftJsonSerializer
+        /// </summary>
+        /// <param name="optionAction"></param>
+        /// <returns></returns>
+        public static NewtonsoftJsonSerializer CreateJsonSerializer(Action<JsonSerializerSettings?>? optionAction = null)
+        {
+            JsonSerializerSettings jsonSerializer = new JsonSerializerSettings();
+            optionAction?.Invoke(jsonSerializer);
+
+            return new NewtonsoftJsonSerializer(jsonSerializer);
+        }
+    }
+}

--- a/WebApiClientCore/WebApiClientCore.csproj
+++ b/WebApiClientCore/WebApiClientCore.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />


### PR DESCRIPTION
解决的问题：
`system.text.json`许多功能不支持，在功能完整性上还需要使用`Newtonsoft.Json`. 添加`Newtonsoft.Json`之后，可以在性能不敏感、看重稳定性、看重稳定性的一些项目中使用。

特殊之处：
1.因为序列化接口是为`system.text.json`准备的，所以为了兼容，我准备全面替换掉原始接口并添加了对应的代码。
2.原代码中有一些序列化配置，与`system.text.json`默认行为保持一致，我添加的代码中没有编码对应配置，完全交由使用方决定。

建议与考虑：
1.建立将序列化部分独立出来，我不想在未讨论的情况下修改，直接在serialization中添加了。
2.建立抽象序列化接口，不要与任何库依赖。该接口可以设计的非常抽象，然后json\xml\其它格式都可以继续添加了。
3.假如接受建议2,可以先合并这次改动，在后续重构中添加考虑，先让NewtonsoftJson用起来。