### PR TITLE
Update WebApiClientCore.OpenApi.SourceGenerator.csproj

### DIFF
--- a/WebApiClientCore.OpenApi.SourceGenerator/WebApiClientCore.OpenApi.SourceGenerator.csproj
+++ b/WebApiClientCore.OpenApi.SourceGenerator/WebApiClientCore.OpenApi.SourceGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5;net6;net7</TargetFrameworks>
   
     <Summary>将本地或远程OpenApi文档解析生成WebApiClientCore的接口定义代码文件的工具</Summary>
     <SatelliteResourceLanguages>zh-Hans</SatelliteResourceLanguages>


### PR DESCRIPTION
添加多目标框架，使客户机可以使用已安装的.NET，免于安装netcore3.1